### PR TITLE
add:seederファイルの作成

### DIFF
--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Model>
+ */
+class CommentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'title' => fake()->word,
+            'body' => fake()->text($maxNbChars = 30),
+            'rating' => rand(1, 5),
+            'snack_id' => rand(1, 30),
+            'user_id' => 1,
+        ];
+    }
+}

--- a/database/factories/SnackFactory.php
+++ b/database/factories/SnackFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Model>
+ */
+class SnackFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'name' => fake()->word,
+            'overview' => fake()->text($maxNbChars = 30),
+        ];
+    }
+}

--- a/database/migrations/2022_11_18_135546_create_comments_table.php
+++ b/database/migrations/2022_11_18_135546_create_comments_table.php
@@ -15,14 +15,13 @@ return new class extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
-            $table->timestamps();
             $table->string('title', 30);
             $table->string('body', 300);
             $table->tinyInteger('rating');
-            $table->timestamps();
-            $table->softDeletes();
             $table->foreignId('snack_id')->constrained();
             $table->foreignId('user_id')->constrained();
+            $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/database/seeders/CommentSeeder.php
+++ b/database/seeders/CommentSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Comment;
+
+class CommentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Comment::factory()->count(60)->create();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,7 +15,10 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         // \App\Models\User::factory(10)->create();
-
+            $this->call([
+                    SnackSeeder::class,
+                    CommentSeeder::class,
+            ]);
         // \App\Models\User::factory()->create([
         //     'name' => 'Test User',
         //     'email' => 'test@example.com',

--- a/database/seeders/SnackSeeder.php
+++ b/database/seeders/SnackSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Snack;
+
+class SnackSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Snack::factory()->count(30)->create();
+    }
+}

--- a/database/seeders/StoreSeeder.php
+++ b/database/seeders/StoreSeeder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class StoreSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('stores')->insert([
+                'name' => 'セブンイレブン',
+                'overview' => '圧倒的高品質。値段が他店より高い,若しくは量が少ない分とても高品質な商品が多い。',
+                'created_at' => new DateTime(),
+                'updated_at' => new DateTime(),
+                
+                
+            ]);
+    
+            DB::table('stores')->insert([
+                'name' => 'ファミリーマート',
+                'overview' => 'とても無難。セブンイレブンに比べ質が少し落ちる分,量がある商品が多い。',
+                'created_at' => new DateTime(),
+                'updated_at' => new DateTime(),
+                
+                
+            ]);
+    
+            DB::table('stores')->insert([
+                'name' => 'ローソン',
+                'overview' => 'コンビニ菓子の中では良くも悪くも目立たない。',
+                'created_at' => new DateTime(),
+                'updated_at' => new DateTime(),
+                
+            ]);
+    
+            DB::table('stores')->insert([
+                'name' => 'まいばすけっと',
+                'overview' => '四種の店の中で唯一コンビニではない枠。この店の一番の強みは何といってもコスパ',
+                'created_at' => new DateTime(),
+                'updated_at' => new DateTime(),
+                
+            ]);
+    }
+}


### PR DESCRIPTION
・storesのシーダーファイル
・commentsのシーダーファイル
・commentsのファクトリファイル
・snacksのシーダーファイル
・snacksのファクトリファイル
上記のファイルの作成により、ダミーデータを追加できるようにした。
また、DatabaseSeederを編集し、上記のファクトリファイルを呼び出せるようにした。

この時点で
・snacksのダミーデータが30個
・commentsのダミーデータが60個
・storesのデータ4個
が追加されるようになってある。