### PR TITLE
add:SnackについてのImage保存,追加,削除機能実装

### DIFF
--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -8,6 +8,7 @@ use App\Models\Image;
 use Illuminate\Http\Request;
 use App\Http\Requests\SnackRequest;
 use App\Http\Requests\SnackEditRequest;
+use App\Http\Requests\SnackImageRequest;
 use Illuminate\Pagination\Paginator;
 use Cloudinary;
 
@@ -53,7 +54,7 @@ class SnackController extends Controller
     }
     
     
-    public function add(Request $request, Snack $snack, Image $image)
+    public function add(SnackImageRequest $request, Snack $snack, Image $image)
     {
         $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
         $image->image_path = $image_url;

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -64,10 +64,13 @@ class SnackController extends Controller
             ->orderBy('created_at', 'DESC')->paginate(10);
         $raw_rating = Comment::where('snack_id', $snack->id)->average('rating');
         $rating = round($raw_rating, 1);
+        // 上のコードをbladeファイル内に書く
+        $image = Image::whereImageable_id($snack->id)->where('imageable_type', 'App\Models\Snack')->get();
         return view('snacks/show')->with([
             'snack' => $snack,
             'comments' => $comment,
-            'rating' => $rating
+            'rating' => $rating,
+            'images' => $image
         ]);
     }
 

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -51,7 +51,17 @@ class SnackController extends Controller
         
         return redirect('/snacks/' . $snack->id);
     }
-
+    
+    
+    public function add(Request $request, Snack $snack, Image $image)
+    {
+        $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
+        $image->image_path = $image_url;
+        $snack->images()->save($image);
+        
+        return redirect('/snacks/' . $snack->id);
+    }
+    
     /**
      * Display the specified resource.
      *

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -46,10 +46,9 @@ class SnackController extends Controller
     {
         $input_snack=$request['snack'];
         $snack->fill($input_snack)->save();
-        $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
         $result = $request->file('image')->storeOnCloudinary();
         $image->public_id = $result->getPublicId();
-        $image->image_path = $image_url;
+        $image->image_path = $result->getSecurePath();
         $snack->images()->save($image);
         
         return redirect('/snacks/' . $snack->id);

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -4,11 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Models\Snack;
 use App\Models\Comment;
+use App\Models\Image;
 use Illuminate\Http\Request;
 use App\Http\Requests\SnackRequest;
 use App\Http\Requests\SnackEditRequest;
 use Illuminate\Pagination\Paginator;
-//cloudinaryとimageモデルのuse宣言をする
+use Cloudinary;
 
 class SnackController extends Controller
 {
@@ -40,11 +41,13 @@ class SnackController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(SnackRequest $request, Snack $snack)
+    public function store(SnackRequest $request, Snack $snack, Image $image)
     {
         $input_snack=$request['snack'];
         $snack->fill($input_snack)->save();
-        //この後の行にimageにかんするコードを記述
+        $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
+        $image->image_path = $image_url;
+        $snack->images()->save($image);
         
         return redirect('/snacks/' . $snack->id);
     }

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -120,8 +120,11 @@ class SnackController extends Controller
      */
     public function delete(Snack $snack, Image $image, Comment $comment)
     {
-        // Cloudinary::destroy($image->public_id); このコードによりcloudinary上の画像も削除される.
+        //  このコードによりcloudinary上の画像も削除される.
         // 後々imagesのテーブルにpublic_idのカラムを追加すべき.
+        foreach($snack->images as $image){
+            Cloudinary::destroy($image->public_id);
+        }
         $snack->delete();
         $snack->images()->delete($image);
         $snack->comments()->delete($comment);

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -117,10 +117,13 @@ class SnackController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function delete(Snack $snack)
+    public function delete(Snack $snack, Image $image, Comment $comment)
     {
+        // Cloudinary::destroy($image->public_id); このコードによりcloudinary上の画像も削除される.
+        // 後々imagesのテーブルにpublic_idのカラムを追加すべき.
         $snack->delete();
-        // この行に、imageとcommentを削除するコードを記述
+        $snack->images()->delete($image);
+        $snack->comments()->delete($comment);
         return redirect('/');
     }
 }

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use App\Http\Requests\SnackRequest;
 use App\Http\Requests\SnackEditRequest;
 use Illuminate\Pagination\Paginator;
+//cloudinaryとimageモデルのuse宣言をする
 
 class SnackController extends Controller
 {

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -121,8 +121,6 @@ class SnackController extends Controller
      */
     public function delete(Snack $snack, Image $image, Comment $comment)
     {
-        //  このコードによりcloudinary上の画像も削除される.
-        // 後々imagesのテーブルにpublic_idのカラムを追加すべき.
         foreach($snack->images as $image){
             Cloudinary::destroy($image->public_id);
         }

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -57,8 +57,9 @@ class SnackController extends Controller
     
     public function add(SnackImageRequest $request, Snack $snack, Image $image)
     {
-        $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
-        $image->image_path = $image_url;
+        $result = $request->file('image')->storeOnCloudinary();
+        $image->public_id = $result->getPublicId();
+        $image->image_path = $result->getSecurePath();
         $snack->images()->save($image);
         
         return redirect('/snacks/' . $snack->id);

--- a/app/Http/Controllers/SnackController.php
+++ b/app/Http/Controllers/SnackController.php
@@ -47,6 +47,8 @@ class SnackController extends Controller
         $input_snack=$request['snack'];
         $snack->fill($input_snack)->save();
         $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
+        $result = $request->file('image')->storeOnCloudinary();
+        $image->public_id = $result->getPublicId();
         $image->image_path = $image_url;
         $snack->images()->save($image);
         

--- a/app/Http/Requests/SnackImageRequest.php
+++ b/app/Http/Requests/SnackImageRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SnackImageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'image' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/SnackRequest.php
+++ b/app/Http/Requests/SnackRequest.php
@@ -25,8 +25,8 @@ class SnackRequest extends FormRequest
     {
         return [
             'snack.name' => 'required|string|max:30',
-            'snack.overview' => 'required|string|max:300'
-            // この行にimageに関するコードを記述
+            'snack.overview' => 'required|string|max:300',
+            'image' => 'required'
         ];
     }
 }

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Image extends Model
 {
-    //softdeleteのuse宣言をする
+    use SoftDeletes;
     
     public function imageable()
     {

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Image extends Model
+{
+    //softdeleteのuse宣言をする
+    
+    public function imageable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Snack.php
+++ b/app/Models/Snack.php
@@ -25,4 +25,9 @@ class Snack extends Model
     {
         return $this->hasMany(Comment::class);
     }
+    
+    public function images()
+    {
+        return $this->morphMany(Image::class, 'imageable');
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0.2",
+        "cloudinary-labs/cloudinary-laravel": "^2.0",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^9.19",
         "laravel/sanctum": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b5927cb7d5e902f86aa7c0ac8b2836c",
+    "content-hash": "f459da22e3cb818a72c53e5ca8bf9d68",
     "packages": [
         {
             "name": "brick/math",
@@ -61,6 +61,203 @@
                 }
             ],
             "time": "2022-08-10T22:54:19+00:00"
+        },
+        {
+            "name": "cloudinary-labs/cloudinary-laravel",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cloudinary-labs/cloudinary-laravel.git",
+                "reference": "f1b74dd7202b1314c8c8729be5b32dc7c3f5427d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary-labs/cloudinary-laravel/zipball/f1b74dd7202b1314c8c8729be5b32dc7c3f5427d",
+                "reference": "f1b74dd7202b1314c8c8729be5b32dc7c3f5427d",
+                "shasum": ""
+            },
+            "require": {
+                "cloudinary/cloudinary_php": "^2.0",
+                "ext-json": "*",
+                "illuminate/support": "~6|~7|~8|^9.0",
+                "php": "^8.0.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.1",
+                "orchestra/testbench": "~4|~5|~6|^7.0",
+                "phpunit/phpunit": "^8.0|^9.5.10",
+                "sempro/phpunit-pretty-print": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "CloudinaryLabs\\CloudinaryLaravel\\CloudinaryServiceProvider"
+                    ],
+                    "aliases": {
+                        "Cloudinary": "CloudinaryLabs\\CloudinaryLaravel\\Facades\\Cloudinary"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Support/helpers.php"
+                ],
+                "psr-4": {
+                    "CloudinaryLabs\\CloudinaryLaravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Prosper Otemuyiwa",
+                    "email": "prosperotemuyiwa@gmail.com",
+                    "homepage": "https://github.com/unicodeveloper"
+                }
+            ],
+            "description": "A Laravel Cloudinary Package",
+            "homepage": "https://github.com/cloudinary-labs/cloudinary-laravel",
+            "keywords": [
+                "File Transformations",
+                "Media management",
+                "cloudinary",
+                "cloudinary-laravel",
+                "file uploads",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/cloudinary-labs/cloudinary-laravel/issues",
+                "source": "https://github.com/cloudinary-labs/cloudinary-laravel/tree/2.0.1"
+            },
+            "time": "2022-06-03T13:17:15+00:00"
+        },
+        {
+            "name": "cloudinary/cloudinary_php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cloudinary/cloudinary_php.git",
+                "reference": "ddd9866c6109ece2f567fd43eda02052fa6c0590"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary/cloudinary_php/zipball/ddd9866c6109ece2f567fd43eda02052fa6c0590",
+                "reference": "ddd9866c6109ece2f567fd43eda02052fa6c0590",
+                "shasum": ""
+            },
+            "require": {
+                "cloudinary/transformation-builder-sdk": "^1",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6|^7",
+                "monolog/monolog": "^1|^2|^3",
+                "php": ">=5.6.0",
+                "psr/log": "^1|^2|^3",
+                "teapot/status-code": "^1|^2"
+            },
+            "require-dev": {
+                "consolidation/robo": "~1",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "*",
+                "phpmd/phpmd": "*",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/phpunit-bridge": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cloudinary",
+                    "homepage": "https://github.com/cloudinary/cloudinary_php/graphs/contributors"
+                }
+            ],
+            "description": "Cloudinary PHP SDK",
+            "homepage": "https://github.com/cloudinary/cloudinary_php",
+            "keywords": [
+                "cdn",
+                "cloud",
+                "cloudinary",
+                "image management",
+                "sdk"
+            ],
+            "support": {
+                "email": "info@cloudinary.com",
+                "issues": "https://github.com/cloudinary/cloudinary_php/issues",
+                "source": "https://github.com/cloudinary/cloudinary_php/tree/2.9.2"
+            },
+            "time": "2022-11-13T14:33:32+00:00"
+        },
+        {
+            "name": "cloudinary/transformation-builder-sdk",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cloudinary/php-transformation-builder-sdk.git",
+                "reference": "3c926d857061339e2b65e7f3c444eab80ea5fe1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary/php-transformation-builder-sdk/zipball/3c926d857061339e2b65e7f3c444eab80ea5fe1e",
+                "reference": "3c926d857061339e2b65e7f3c444eab80ea5fe1e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "consolidation/robo": "~1",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "*",
+                "phpmd/phpmd": "*",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cloudinary",
+                    "homepage": "https://github.com/cloudinary/php-transformation-builder-sdk/graphs/contributors"
+                }
+            ],
+            "description": "Cloudinary PHP Transformation Builder SDK",
+            "homepage": "https://github.com/cloudinary/php-transformation-builder-sdk",
+            "keywords": [
+                "cdn",
+                "cloud",
+                "cloudinary",
+                "image management",
+                "sdk"
+            ],
+            "support": {
+                "email": "info@cloudinary.com",
+                "issues": "https://github.com/cloudinary/php-transformation-builder-sdk/issues",
+                "source": "https://github.com/cloudinary/php-transformation-builder-sdk/tree/1.0.0"
+            },
+            "time": "2022-05-24T08:16:26+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -5082,6 +5279,57 @@
                 }
             ],
             "time": "2022-10-07T08:02:12+00:00"
+        },
+        {
+            "name": "teapot/status-code",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/teapot-php/status-code.git",
+                "reference": "39cce90f07bf2a906d19e6de9418e0382e75e0bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/teapot-php/status-code/zipball/39cce90f07bf2a906d19e6de9418e0382e75e0bf",
+                "reference": "39cce90f07bf2a906d19e6de9418e0382e75e0bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Teapot\\StatusCode\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barney Hanlon",
+                    "email": "barney@shrikeh.net"
+                },
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "PHP HTTP Response Status code library",
+            "homepage": "https://github.com/teapot-php/status-code",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "issues": "https://github.com/teapot-php/status-code/issues",
+                "source": "https://github.com/teapot-php/status-code/tree/2.0.0"
+            },
+            "time": "2022-09-22T13:59:09+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/config/app.php
+++ b/config/app.php
@@ -192,6 +192,7 @@ return [
          */
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
+        CloudinaryLabs\CloudinaryLaravel\CloudinaryServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,

--- a/config/cloudinary.php
+++ b/config/cloudinary.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Laravel Cloudinary package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cloudinary Configuration
+    |--------------------------------------------------------------------------
+    |
+    | An HTTP or HTTPS URL to notify your application (a webhook) when the process of uploads, deletes, and any API
+    | that accepts notification_url has completed.
+    |
+    |
+    */
+    'notification_url' => env('CLOUDINARY_NOTIFICATION_URL'),
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cloudinary Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Cloudinary settings. Cloudinary is a cloud hosted
+    | media management service for all file uploads, storage, delivery and transformation needs.
+    |
+    |
+    */
+    'cloud_url' => env('CLOUDINARY_URL'),
+
+    /**
+     * Upload Preset From Cloudinary Dashboard
+     *
+     */
+    'upload_preset' => env('CLOUDINARY_UPLOAD_PRESET')
+];

--- a/database/migrations/2022_11_18_140733_create_images_table.php
+++ b/database/migrations/2022_11_18_140733_create_images_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
         Schema::create('images', function (Blueprint $table) {
             $table->id();
             $table->string('image_path', 200);
+            $table->string('public_id', 200);
             $table->integer('imageable_id');
             $table->string('imageable_type');
             $table->timestamps();

--- a/resources/views/snacks/create.blade.php
+++ b/resources/views/snacks/create.blade.php
@@ -22,9 +22,10 @@
             </div>
             <div class='image'>
                 <h2 style='padding: 20px 0 0 0;'>画像:</h2>
-                {{-- 画像の追加フォームのコードをここに記述 --}}
+                <input type="file" name="image">
+                <button>画像をアップロード</button>
             </div>
-            <input type="submit" value="保存"/>
+            <input type="submit" value="保存" style='padding: 15px 0;'/>
         </form>
         <div class="back" style='padding: 0 0 0 50px;'>[<a href="/">戻る</a>]</div>
     </body>

--- a/resources/views/snacks/create.blade.php
+++ b/resources/views/snacks/create.blade.php
@@ -23,7 +23,6 @@
             <div class='image'>
                 <h2 style='padding: 20px 0 0 0;'>画像:</h2>
                 <input type="file" name="image">
-                <button>画像をアップロード</button>
             </div>
             <input type="submit" value="保存" style='padding: 15px 0;'/>
         </form>

--- a/resources/views/snacks/create.blade.php
+++ b/resources/views/snacks/create.blade.php
@@ -23,6 +23,7 @@
             <div class='image'>
                 <h2 style='padding: 20px 0 0 0;'>画像:</h2>
                 <input type="file" name="image">
+                <p class='image_error' style='color:red'>{{ $errors->first('image') }}</p>
             </div>
             <input type="submit" value="保存" style='padding: 15px 0;'/>
         </form>

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -14,7 +14,11 @@
         <h1 class="name" style='padding: 10px 0 0 50px;'>
             {{ $snack->name }}
         </h1>
-        {{-- お菓子の追加、表示機能をこの間に記述する --}}
+        <div class="image" style='padding: 10px 0 0 30px;'>
+            @foreach($images as $image)
+                <img src="{{ $image->image_path }}">
+            @endforeach
+        </div>
         <div class="content" style='padding: 20px 70px;'>
             <div class="content__snack">
                 <h2>コンビニ名</h2>

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -24,6 +24,7 @@
                 <div class='add_image'>
                     <input type="file" name="image"/>
                     <input type="submit" value="追加"/>
+                    <p style='color:red'>{{ $errors->first('image') }}</p>
                 </div>
             </form>
         </div>

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -18,6 +18,14 @@
             @foreach($images as $image)
                 <img src="{{ $image->image_path }}">
             @endforeach
+            <h2 style='padding: 10px 0 0 30px;'>お菓子の画像を追加する</h2>
+            <form action='/snacks/{{ $snack->id }}' method='POST' enctype='multipart/form-data'>
+                @csrf
+                <div class='image'>
+                    <input type="file" name="image"/>
+                    <input type="submit" value="追加"/>
+                </div>
+            </form>
         </div>
         <div class="content" style='padding: 20px 70px;'>
             <div class="content__snack">

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -21,7 +21,7 @@
             <h2 style='padding: 10px 0 0 30px;'>お菓子の画像を追加する</h2>
             <form action='/snacks/{{ $snack->id }}' method='POST' enctype='multipart/form-data'>
                 @csrf
-                <div class='image'>
+                <div class='add_image'>
                     <input type="file" name="image"/>
                     <input type="submit" value="追加"/>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ Route::get('/comments/{snack}/create', [CommentController::class, 'create']);
 Route::get('/snacks/{snack}/edit', [SnackController::class, 'edit']);
 Route::get('/snacks/{snack}', [SnackController::class, 'show']);
 Route::put('/snacks/{snack}', [SnackController::class, 'update']);
+Route::post('/snacks/{snack}', [SnackController::class, 'add']);
 Route::post('/snacks', [SnackController::class, 'store']);
 Route::delete('/snacks/{snack}', [SnackController::class, 'delete']);
 


### PR DESCRIPTION
・Cloudinaryを用いて画像をアップロードし、保存できるようにした
・お菓子のcreateページにて、そのお菓子についての画像も保存できるようにした
・元々あるお菓子に対して、追加でお菓子を保存できる機能を実装
・お菓子の削除時、それに連なってmysql上の画像が削除される機能を実装
・お菓子の削除時、それに連なってCloudinary上の画像が削除される機能を実装(複数枚)
・お菓子のcreateページにおいて画像のバリデーション機能を実装
・元々あるお菓子に対しての画像追加時におけるバリデーション機能を実装

元々はCloudinaryに画像をアップロードした際にそのURLのみを取得しmysqlに保存する流れだったが、それだと画像の削除時にCloudinary上では画像が残ってしまう。
それを解決するため、imagesテーブルのカラムにpublic_idを追加。画像の削除時に、public_idを参照しそれと一致する画像をCloudinaryでも削除されるようコードを書いた。その際にポリモーフィックリレーションとforeachを用い、画像が複数枚保存されていてもCloudinary 上でそれらすべて削除されるようにした。

現時点でお菓子についての画像を編集,変更する機能は実装されていない。