### PR TITLE
fix:seederファイルの修正

### DIFF
--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -20,7 +20,7 @@ class CommentFactory extends Factory
             'title' => fake()->word,
             'body' => fake()->text($maxNbChars = 30),
             'rating' => rand(1, 5),
-            'snack_id' => rand(1, 30),
+            'snack_id' => rand(1, 100),
             'user_id' => rand(1,3),
         ];
     }

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -21,7 +21,7 @@ class CommentFactory extends Factory
             'body' => fake()->text($maxNbChars = 30),
             'rating' => rand(1, 5),
             'snack_id' => rand(1, 30),
-            'user_id' => 1,
+            'user_id' => rand(1,3),
         ];
     }
 }

--- a/database/seeders/CommentSeeder.php
+++ b/database/seeders/CommentSeeder.php
@@ -15,6 +15,6 @@ class CommentSeeder extends Seeder
      */
     public function run()
     {
-        Comment::factory()->count(60)->create();
+        Comment::factory()->count(300)->create();
     }
 }

--- a/database/seeders/CommentSeeder.php
+++ b/database/seeders/CommentSeeder.php
@@ -15,6 +15,6 @@ class CommentSeeder extends Seeder
      */
     public function run()
     {
-        Comment::factory()->count(500)->create();
+        Comment::factory()->count(1000)->create();
     }
 }

--- a/database/seeders/CommentSeeder.php
+++ b/database/seeders/CommentSeeder.php
@@ -15,6 +15,6 @@ class CommentSeeder extends Seeder
      */
     public function run()
     {
-        Comment::factory()->count(300)->create();
+        Comment::factory()->count(500)->create();
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,7 +17,8 @@ class DatabaseSeeder extends Seeder
         // \App\Models\User::factory(10)->create();
             $this->call([
                     SnackSeeder::class,
-                    CommentSeeder::class,
+                    StoreSeeder::class,
+                    SnackStoreSeeder::class,
             ]);
         // \App\Models\User::factory()->create([
         //     'name' => 'Test User',

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,6 +21,7 @@ class DatabaseSeeder extends Seeder
                     SnackStoreSeeder::class,
                     UserSeeder::class,
                     CommentSeeder::class,
+                    ImageSeeder::class,
 
             ]);
         // \App\Models\User::factory()->create([

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,9 @@ class DatabaseSeeder extends Seeder
                     SnackSeeder::class,
                     StoreSeeder::class,
                     SnackStoreSeeder::class,
+                    UserSeeder::class,
+                    CommentSeeder::class,
+
             ]);
         // \App\Models\User::factory()->create([
         //     'name' => 'Test User',

--- a/database/seeders/ImageSeeder.php
+++ b/database/seeders/ImageSeeder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Seeder;
+use DateTime;
+
+class ImageSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $id_path = array(
+            'snack2_fhkvvs' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669915997/snack2_fhkvvs.jpg',
+            'snack1_w3jabn' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669915997/snack1_w3jabn.jpg',
+            'snack5_p8by4v' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669915997/snack5_p8by4v.jpg',
+            'snack3_vrqgu6' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669915997/snack3_vrqgu6.jpg',
+            'snack4_nr2q33' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669915997/snack4_nr2q33.jpg',
+            );
+        
+        DB::table('images')->insert([
+                'image_path' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669915616/%E3%82%BB%E3%83%96%E3%83%B3%E3%82%A4%E3%83%AC%E3%83%96%E3%83%B3_nhfxiz.png',
+                'public_id' => 'セブンイレブン_nhfxiz',
+                'imageable_id' => '1',
+                'imageable_type' => 'App\Models\Store',
+                'created_at' => new DateTime(),
+                'updated_at' => new DateTime(),
+            ]);
+        
+        DB::table('images')->insert([
+                'image_path' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669550322/%E3%83%95%E3%82%A1%E3%83%9F%E3%83%AA%E3%83%BC%E3%83%9E%E3%83%BC%E3%83%88_zdxsht.png',
+                'public_id' => 'ファミリーマート_zdxsht',
+                'imageable_id' => '2',
+                'imageable_type' => 'App\Models\Store',
+                'created_at' => new DateTime(),
+                'updated_at' => new DateTime(),
+            ]);
+        
+        DB::table('images')->insert([
+                'image_path' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669550322/%E3%83%AD%E3%83%BC%E3%82%BD%E3%83%B3_kin9ag.png',
+                'public_id' => 'ローソン_kin9ag',
+                'imageable_id' => '3',
+                'imageable_type' => 'App\Models\Store',
+                'created_at' => new DateTime(),
+                'updated_at' => new DateTime(),
+            ]);
+        
+        DB::table('images')->insert([
+                'image_path' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669550322/%E3%81%BE%E3%81%84%E3%81%B0%E3%81%99%E3%81%91%E3%81%A3%E3%81%A8_o71rbm.png',
+                'public_id' => 'まいばすけっと_o71rbm',
+                'imageable_id' => '4',
+                'imageable_type' => 'App\Models\Store',
+                'created_at' => new DateTime(),
+                'updated_at' => new DateTime(),
+            ]);
+        for ($i = 5; $i < 35; $i++){
+            $image_path = $id_path[array_rand($id_path, 1)];
+            DB::table('images')->insert([
+                'image_path' => $image_path,
+                'public_id' => array_search($image_path, $id_path),
+                'imageable_id' => $i,
+                'imageable_type' => 'App\Models\Snack',
+                'created_at' => new DateTime(),
+                'updated_at' => new DateTime(),
+            ]);
+        }
+    }
+}

--- a/database/seeders/ImageSeeder.php
+++ b/database/seeders/ImageSeeder.php
@@ -22,6 +22,14 @@ class ImageSeeder extends Seeder
             'snack5_p8by4v' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669915997/snack5_p8by4v.jpg',
             'snack3_vrqgu6' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669915997/snack3_vrqgu6.jpg',
             'snack4_nr2q33' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669915997/snack4_nr2q33.jpg',
+            'snack12_i2ofua' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669919519/snack12_i2ofua.jpg',
+            'snack6_xtzmmk' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669919519/snack6_xtzmmk.jpg',
+            'snack13_w03zz9' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669919518/snack13_w03zz9.jpg',
+            'snack8_wzynxh' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669919518/snack8_wzynxh.jpg',
+            'snack9_wad0gz' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669919518/snack9_wad0gz.jpg',
+            'snack10_dlzgh4' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669919518/snack10_dlzgh4.jpg',
+            'snack11_maparo' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669919518/snack11_maparo.jpg',
+            'snack7_du5aei' => 'https://res.cloudinary.com/dcfv11t63/image/upload/v1669919518/snack7_du5aei.jpg',
             );
         
         DB::table('images')->insert([
@@ -59,7 +67,7 @@ class ImageSeeder extends Seeder
                 'created_at' => new DateTime(),
                 'updated_at' => new DateTime(),
             ]);
-        for ($i = 5; $i < 35; $i++){
+        for ($i = 5; $i < 105; $i++){
             $image_path = $id_path[array_rand($id_path, 1)];
             DB::table('images')->insert([
                 'image_path' => $image_path,

--- a/database/seeders/ImageSeeder.php
+++ b/database/seeders/ImageSeeder.php
@@ -67,7 +67,7 @@ class ImageSeeder extends Seeder
                 'created_at' => new DateTime(),
                 'updated_at' => new DateTime(),
             ]);
-        for ($i = 5; $i < 105; $i++){
+        for ($i = 1; $i < 101; $i++){
             $image_path = $id_path[array_rand($id_path, 1)];
             DB::table('images')->insert([
                 'image_path' => $image_path,

--- a/database/seeders/SnackSeeder.php
+++ b/database/seeders/SnackSeeder.php
@@ -15,6 +15,6 @@ class SnackSeeder extends Seeder
      */
     public function run()
     {
-        Snack::factory()->count(30)->create();
+        Snack::factory()->count(100)->create();
     }
 }

--- a/database/seeders/SnackStoreSeeder.php
+++ b/database/seeders/SnackStoreSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Seeder;
+use DateTime;
+use App\Models\Snack;
+use App\Models\Store;
+
+class SnackStoreSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        for ($i = 0; $i < 30; $i++){
+            $set_snack_id = Snack::select('id')->orderByRaw('rand()')->first()->id;
+            $set_store_id = Store::select('id')->orderByRaw('rand()')->first()->id;
+            
+            $snack_store = DB::table('snack_store')
+                            ->where([
+                                ['snack_id', '=', $set_snack_id],
+                                ['store_id', '=', $set_store_id]
+                            ])->get();
+            
+            if($snack_store->isEmpty()){
+                DB::table('snack_store')->insert([
+                    'snack_id' => $set_snack_id,
+                    'store_id' => $set_store_id,
+                ]);
+            } else {
+                $i--;
+            }
+            
+        }
+    }
+}

--- a/database/seeders/SnackStoreSeeder.php
+++ b/database/seeders/SnackStoreSeeder.php
@@ -18,15 +18,21 @@ class SnackStoreSeeder extends Seeder
      */
     public function run()
     {
-        for ($i = 0; $i < 30; $i++){
+        for ($i = 1;$i < 101; $i++){
+            DB::table('snack_store')->insert([
+                    'snack_id' => $i,
+                    'store_id' => rand(1,4),
+                ]);
+        }
+        
+        for ($i = 0;$i < 50; $i++){
             $set_snack_id = Snack::select('id')->orderByRaw('rand()')->first()->id;
             $set_store_id = Store::select('id')->orderByRaw('rand()')->first()->id;
             
-            $snack_store = DB::table('snack_store')
-                            ->where([
-                                ['snack_id', '=', $set_snack_id],
-                                ['store_id', '=', $set_store_id]
-                            ])->get();
+            $snack_store = DB::table('snack_store')->where([
+                    ['snack_id', '=' , $set_snack_id],
+                    ['store_id', '=' , $set_store_id],
+            ])->get();
             
             if($snack_store->isEmpty()){
                 DB::table('snack_store')->insert([
@@ -36,7 +42,6 @@ class SnackStoreSeeder extends Seeder
             } else {
                 $i--;
             }
-            
         }
     }
 }

--- a/database/seeders/StoreSeeder.php
+++ b/database/seeders/StoreSeeder.php
@@ -3,7 +3,9 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Seeder;
+use DateTime;
 
 class StoreSeeder extends Seeder
 {

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('users')->insert([
+                'name' => 'administrator',
+                'email' => 'admin@test',
+                'email_verified_at' => now(),
+                'password' => bcrypt('adminpass'),
+                'remember_token' => Str::random(10),
+            ]);
+        
+        DB::table('users')->insert([
+                'name' => 'user1',
+                'email' => 'user1@test',
+                'email_verified_at' => now(),
+                'password' => bcrypt('user1pass'),
+                'remember_token' => Str::random(10),
+            ]);
+        
+        DB::table('users')->insert([
+                'name' => 'user2',
+                'email' => 'user2@test',
+                'email_verified_at' => now(),
+                'password' => bcrypt('user2pass'),
+                'remember_token' => Str::random(10),
+            ]);
+    }
+}


### PR DESCRIPTION
・snackのダミーデータが100件追加されるようにSnackFactoryを編集した。
・commentのダミーデータが1000件追加されるようにCommentFactoryを編集した。
・storeの画像を4件追加した。
・snackの画像を13件追加し、各snackにランダムに1件割り当てられるようにした。
→snackの画像についてpublic_idとimage_pathを連想配列で登録し、array_rand()関数により要素(image_path)をランダム取得。ランダムに取得した要素(image_path)から、array_search()関数を用いてキー(public_id)を逆算して抽出する。これにより、image_pathとpublic_idがCloudinary 上で連動する。

・snackとstoreの中間テーブルに、各snackに最低一つ以上のstoreがランダムに割り当てられるようにした。
→for文の二回使用。一回目で各snackにstoreをランダムに1つ割り当て。二回目に、一回目で割り当てられたstore以外のstoreを割り当てた。

現時点で一枚の画像が複数のsnackに使用されているため、一つsnackを削除した場合連動して別のお菓子の画像も消えてしまう。