### PR TITLE
fix:レイアウトの修正

### DIFF
--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -65,7 +65,7 @@ class StoreController extends Controller
      */
     public function show(Store $store)
     {
-        $snack = Store::find($store->id)->snacks()->orderBy('created_at', 'DESC')->paginate(1);
+        $snack = Store::find($store->id)->snacks()->orderBy('created_at', 'DESC')->paginate(10);
         $image = Image::whereImageable_id($store->id)->where('imageable_type', 'App\Models\Store')->first();
         return view('stores.show')->with([
             'store' => $store,

--- a/resources/views/comments/create.blade.php
+++ b/resources/views/comments/create.blade.php
@@ -18,7 +18,7 @@
             </div>
             <div class="body">
                 <h2 style='padding: 10px 0 0 0;'>内容:</h2>
-                <textarea name="comment[body]" placeholder="コメントを記載">{{ old('comment.body') }}</textarea>
+                <textarea name="comment[body]" placeholder="コメントを記載" style="width:40%; height:80px;">{{ old('comment.body') }}</textarea>
                 <p class="body__error" style="color:red">{{ $errors->first('comment.body') }}</p>
                 <h2 style='padding: 10px 0 0 0;'>評価:</h2>
                 <input type="number" name="comment[rating]" min="1" max="5" value={{ old('comment.rating') }}>

--- a/resources/views/comments/edit.blade.php
+++ b/resources/views/comments/edit.blade.php
@@ -24,7 +24,7 @@
             </div>
             <div class='content__body'>
                 <h2 style='padding: 10px 0 0 0;'>内容:</h2>
-                <textarea name='comment[body]'>{{ $comment->body }}</textarea>
+                <textarea name='comment[body]' style="width:40%; height:80px;">{{ $comment->body }}</textarea>
                 <p class='comment_body' style='color:red'>{{ $errors->first('comment.body') }}</p>
             </div>
             <div class='content__average'>

--- a/resources/views/comments/show.blade.php
+++ b/resources/views/comments/show.blade.php
@@ -66,7 +66,7 @@
         @endguest
         
         <div class='to_previous' style='padding: 10px 50px;'>
-            <a href="{{ url()->previous() }}">[戻る]</a>
+            <a href="/snacks/{{ $comment->snack->id }}">[{{ $comment->snack->name }}に戻る]</a>
         </div>
         
         <script>

--- a/resources/views/snacks/create.blade.php
+++ b/resources/views/snacks/create.blade.php
@@ -24,7 +24,7 @@
             </div>
             <div class="overview">
                 <h2 style='padding: 20px 0 0 0;'>詳細:</h2>
-                <textarea name="snack[overview]" placeholder="そのお菓子の詳細について記入してください">{{ old('snack.overview') }}</textarea>
+                <textarea name="snack[overview]" placeholder="そのお菓子の詳細について記入してください" style="width:40%; height:80px;">{{ old('snack.overview') }}</textarea>
                 <p class="overview__error" style="color:red">{{ $errors->first('snack.overview') }}</p>
             </div>
             <div class='image'>

--- a/resources/views/snacks/edit.blade.php
+++ b/resources/views/snacks/edit.blade.php
@@ -35,7 +35,7 @@
             </div>
             <div class='content__overview'>
                 <h2>詳細:</h2>
-                <textarea name='snack[overview]' >{{ $snack->overview }}</textarea>
+                <textarea name='snack[overview]' style="width:40%; height:80px;">{{ $snack->overview }}</textarea>
                 <p class="overview__error" style="color:red">{{ $errors->first('snack.overview') }}</p>
             </div>
             <input type="submit" value="保存">

--- a/resources/views/snacks/index.blade.php
+++ b/resources/views/snacks/index.blade.php
@@ -29,7 +29,7 @@
             @endforeach
         </div>
         <div class='paginate' style='padding: 0 0 0 70px;'>
-            {{ $snacks->links() }}
+            {{ $snacks->links('vendor.pagination.tailwind2') }}
         </div>
         
         @if(Auth::id() == implode(config('app.admin')))

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -56,8 +56,7 @@
         </div>
         
         @auth
-            <a href='/comments/{{ $snack->id }}/create' style='padding: 0 0 0 70px;'>[口コミを投稿]</a>
-            {{-- divで<a>タグを囲む --}}
+            <div class='create' style='padding: 0 0 0 70px;'><a href='/comments/{{ $snack->id }}/create'>[口コミを投稿]</a></div>
         @endauth
         
         @if(Auth::id() == implode(config('app.admin')))

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -47,7 +47,7 @@
             <h3 style='padding: 10px 70px;'>このお菓子への投稿　最新10件</h3>
             @foreach($comments as $comment)
                 <div class='comment_content' style='padding: 5px 70px;'>
-                    <a href="/comments/{{ $comment->id }}">{{ $comment->title }}</a><br>
+                    <a href="/comments/{{ $comment->id }}">・{{ $comment->title }}</a><br>
                 </div>
             @endforeach  
             <div class='paginate' style='padding: 0 0 0 70px;'>

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -40,7 +40,7 @@
                 @endforeach
                 <h2>お菓子の詳細</h2>
                 <p>{{ $snack->overview }}</p>
-                <h2>評価：{{ $rating }}</h2>
+                <h2 style='padding: 10px 0'>評価：{{ $rating }}</h2>
             </div>
         </div>
         <div class='comment'>

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -46,7 +46,7 @@
         <div class='comment'>
             <h3 style='padding: 10px 70px;'>このお菓子への投稿　最新10件</h3>
             @foreach($comments as $comment)
-                <div class='comment_content' style='padding: 5px 70px;'>
+                <div class='comment_content' style='padding: 5px 90px;'>
                     <a href="/comments/{{ $comment->id }}">・{{ $comment->title }}</a><br>
                 </div>
             @endforeach  

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -54,19 +54,14 @@
                 {{ $comments->links('vendor.pagination.tailwind2') }}
             </div>
         </div>
-        
         @auth
             <div class='create' style='padding: 0 0 0 70px;'><a href='/comments/{{ $snack->id }}/create'>[口コミを投稿]</a></div>
         @endauth
-        
         @if(Auth::id() == implode(config('app.admin')))
-            <a href='/snacks/{{ $snack->id }}/edit' style='padding: 10px 70px;'>[編集]</a>
+            <div class='edit' style='padding: 10px 70px;'>
+                <a href='/snacks/{{ $snack->id }}/edit'>[編集]</a>
+            </div>
         @endif
-        {{--
-        <div class='edit' style='padding: 10px 70px;'>
-            <a href='/snacks/{{ $snack->id }}/edit'>[編集]</a>
-        </div>
-        --}}
         <div class="footer" style='padding: 20px 0 0 50px;'>
             <a href="/" >戻る</a>
         </div>

--- a/resources/views/snacks/show.blade.php
+++ b/resources/views/snacks/show.blade.php
@@ -34,13 +34,13 @@
             <div class="content__snack">
                 <h2>店名</h2>
                 @foreach($snack->stores as $store)
-                    <div class='store' style='padding: 10px 0;'>
+                    <div class='store' style='padding: 10px 20px;'>
                         <a href='/stores/{{ $store->id }}'>・{{ $store->name }}</a>
                     </div>
                 @endforeach
                 <h2>お菓子の詳細</h2>
                 <p>{{ $snack->overview }}</p>
-                <h2 style='padding: 10px 0'>評価：{{ $rating }}</h2>
+                <h2 style='padding: 15px 0'>評価：{{ $rating }}</h2>
             </div>
         </div>
         <div class='comment'>

--- a/resources/views/stores/create.blade.php
+++ b/resources/views/stores/create.blade.php
@@ -17,7 +17,7 @@
             </div>
             <div class="overview">
                 <h2 style='padding: 20px 0 0 0;'>詳細:</h2>
-                <textarea name="store[overview]" placeholder="そのお店の詳細について記入してください">{{ old('store.overview') }}</textarea>
+                <textarea name="store[overview]" placeholder="そのお店の詳細について記入してください" style="width:40%; height:80px;">{{ old('store.overview') }}</textarea>
                 <p class="overview__error" style="color:red">{{ $errors->first('store.overview') }}</p>
             </div>
             <div class='image'>

--- a/resources/views/stores/edit.blade.php
+++ b/resources/views/stores/edit.blade.php
@@ -23,7 +23,7 @@
             </div>
             <div class='content__overview' style='padding: 10px 70px;'>
                 <h2>詳細:</h2>
-                <textarea name='store[overview]' >{{ $store->overview }}</textarea>
+                <textarea name='store[overview]' style="width:40%; height:80px;">{{ $store->overview }}</textarea>
                 <p class="overview__error" style="color:red">{{ $errors->first('store.overview') }}</p>
             </div>
             <input type="submit" value="保存" style='padding: 5px 70px;'>

--- a/resources/views/vendor/pagination/tailwind2.blade.php
+++ b/resources/views/vendor/pagination/tailwind2.blade.php
@@ -25,17 +25,18 @@
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
             <div>
                 <p class="text-sm text-gray-700 leading-5">
-                    {!! __('表示中') !!}
+                    {!! __('最新の') !!}
                     @if ($paginator->firstItem())
                         <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                        {!! __('から') !!}
+                        {!! __('件から') !!}
                         <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                        {!! __('件を表示') !!}
                     @else
                         {{ $paginator->count() }}
                     @endif
                     {!! __('　全') !!}
                     <span class="font-medium">{{ $paginator->total() }}</span>
-                    {!! __('件') !!}
+                    {!! __('件中') !!}
                 </p>
             </div>
 


### PR DESCRIPTION
・snackのindexファイルにてページネーションに使用されるものをデフォルトからカスタムされたCSSに変更した
・お店詳細ページ(stores show.blade.php)にて表示されるお菓子の件数を、1件ずつから10件ずつに変更した
・ページネートされた際の表示文を分かりやすいものに変更した

・お菓子詳細ページ(snacks show.blade.php)にてコメント一覧のパディングを変更した
・お菓子詳細ページ(snacks show.blade.php)にて該当するお店のパディングを変更した
・お菓子詳細ページ(snacks show.blade.php)にて評価についてのパディングを変更した

・お菓子追加ページ(snacks create.blade.php)にて、詳細記入欄の幅を広げた
・お菓子編集ページ(snacks edit.blade.php)にて、詳細記入欄の幅を広げた
・お店追加ページ(stores create.blade.php)にて、詳細記入欄の幅を広げた
・お店編集ページ(stores edit.blade.php)にて、詳細記入欄の幅を広げた
・コメント投稿ページ(comments create.blade.php)にて、詳細記入欄の幅を広げた
・コメント編集ページ(comments edit.blade.php)にて、詳細記入欄の幅を広げた

現時点ではtextareaの幅をデフォルトで拡大縮小することができない。
また、文章の見やすさについては後々改善する