### PR TITLE
fix:seederファイルの編集

### DIFF
--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -20,7 +20,7 @@ class CommentFactory extends Factory
             'title' => fake()->word,
             'body' => fake()->text($maxNbChars = 30),
             'rating' => mt_rand(1, 5),
-            'snack_id' => mt_rand(1, 30),
+            'snack_id' => mt_rand(1, 100),
             'user_id' => mt_rand(1,3),
         ];
     }


### PR DESCRIPTION
commentseederの編集.
ランダムで生成されるコメントのダミーデータのsnack_idの範囲が[1~30]だったのを[1~100]に変更した.